### PR TITLE
add rails-controller-testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem 'rspec-rails', '~> 5.0.0'
   gem 'capybara'
+  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,10 @@ GEM
       activesupport (= 7.0.1)
       bundler (>= 1.15.0)
       railties (= 7.0.1)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -245,6 +249,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.1)
+  rails-controller-testing
   rspec-rails (~> 5.0.0)
   simplecov
   simplecov-cobertura


### PR DESCRIPTION
Added gem for rails-controller-testing to gain the assert_template test functionality no longer included in the core of rspec rails, as recommended by the rspec rails documentation for testing requests.

https://relishapp.com/rspec/rspec-rails/docs/matchers/render-template-matcher